### PR TITLE
Pattern for doing parallel work off UI thread.

### DIFF
--- a/DigitDisplay/DigitDisplay.csproj
+++ b/DigitDisplay/DigitDisplay.csproj
@@ -40,6 +40,9 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
@@ -103,6 +106,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/DigitDisplay/packages.config
+++ b/DigitDisplay/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This code shows the basic pattern of doing parallel work and also keeping the UI updated. Specifically:

- Use `await Task.Run(() => ... parallel code ...);` to push the parallel work off the UI thread.
   - `Parallel`, PLINQ, etc. all use the calling thread as one of their worker threads, so this doesn't work well with the UI thread. The `Task.Run` pushes *all* the parallel work off the UI thread and onto the thread pool.
   - But just `Task.Run` has a fire-and-forget problem; specifically, any exceptions would be ignored. Using `await Task.Run` makes the UI thread observe the background work for completion/exceptions/results.
- Propagate `async`/`await` in the UI code up from that point.
- Use `IProgress<T>`/`Progress<T>` for progress updates. This is cleaner than the sub-task approach (`StartNew` with UI `TaskScheduler`) because:
   - No background code is aware of UI elements, or the code needed to update the UI. As far as the code in the `Parallel.ForEach` is concerned, it's only sending updates to its caller, which could be a UI, Console window, or WebSocket as far as it cares. Or they could just be ignored, if you wanted to do a headless comparison.
   - No need to mess with the low-level `TaskScheduler` type. `Progress<T>` handles the thread marshaling implicitly.